### PR TITLE
Add support for allowing multi-dimensional inputs (ndim > 2) #minor

### DIFF
--- a/hiclass/HierarchicalClassifier.py
+++ b/hiclass/HierarchicalClassifier.py
@@ -8,7 +8,6 @@ from joblib import Parallel, delayed
 from sklearn.base import BaseEstimator
 from sklearn.linear_model import LogisticRegression
 from sklearn.utils.validation import _check_sample_weight
-
 try:
     import ray
 except ImportError:
@@ -136,7 +135,7 @@ class HierarchicalClassifier(abc.ABC):
 
         if not self.bert:
             self.X_, self.y_ = self._validate_data(
-                X, y, multi_output=True, accept_sparse="csr"
+                X, y, multi_output=True, accept_sparse="csr", allow_nd=True
             )
         else:
             self.X_ = np.array(X)

--- a/hiclass/HierarchicalClassifier.py
+++ b/hiclass/HierarchicalClassifier.py
@@ -8,6 +8,7 @@ from joblib import Parallel, delayed
 from sklearn.base import BaseEstimator
 from sklearn.linear_model import LogisticRegression
 from sklearn.utils.validation import _check_sample_weight
+
 try:
     import ray
 except ImportError:

--- a/hiclass/LocalClassifierPerLevel.py
+++ b/hiclass/LocalClassifierPerLevel.py
@@ -140,7 +140,7 @@ class LocalClassifierPerLevel(BaseEstimator, HierarchicalClassifier):
 
         # Input validation
         if not self.bert:
-            X = check_array(X, accept_sparse="csr")
+            X = check_array(X, accept_sparse="csr", allow_nd=True, ensure_2d=False)
         else:
             X = np.array(X)
 

--- a/hiclass/LocalClassifierPerNode.py
+++ b/hiclass/LocalClassifierPerNode.py
@@ -150,7 +150,7 @@ class LocalClassifierPerNode(BaseEstimator, HierarchicalClassifier):
 
         # Input validation
         if not self.bert:
-            X = check_array(X, accept_sparse="csr")
+            X = check_array(X, accept_sparse="csr", allow_nd=True, ensure_2d=False)
         else:
             X = np.array(X)
 

--- a/hiclass/LocalClassifierPerParentNode.py
+++ b/hiclass/LocalClassifierPerParentNode.py
@@ -133,7 +133,7 @@ class LocalClassifierPerParentNode(BaseEstimator, HierarchicalClassifier):
 
         # Input validation
         if not self.bert:
-            X = check_array(X, accept_sparse="csr")
+            X = check_array(X, accept_sparse="csr", allow_nd=True, ensure_2d=False)
         else:
             X = np.array(X)
 

--- a/tests/test_LocalClassifierPerLevel.py
+++ b/tests/test_LocalClassifierPerLevel.py
@@ -216,6 +216,7 @@ def test_knn():
     # predictions = lcpl.predict(X)
     # assert_array_equal(y, predictions)
 
+
 def test_fit_multiple_dim_input():
     lcpl = LocalClassifierPerLevel()
     X = np.random.rand(1, 275, 3)
@@ -230,3 +231,4 @@ def test_predict_multiple_dim_input():
     y = np.array([["a", "b", "c"]])
     lcpl.fit(X, y)
     predictions = lcpl.predict(X)
+    assert predictions is not None

--- a/tests/test_LocalClassifierPerLevel.py
+++ b/tests/test_LocalClassifierPerLevel.py
@@ -215,3 +215,18 @@ def test_knn():
     check_is_fitted(lcpl)
     # predictions = lcpl.predict(X)
     # assert_array_equal(y, predictions)
+
+def test_fit_multiple_dim_input():
+    lcpl = LocalClassifierPerLevel()
+    X = np.random.rand(1, 275, 3)
+    y = np.array([["a", "b", "c"]])
+    lcpl.fit(X, y)
+    check_is_fitted(lcpl)
+
+
+def test_predict_multiple_dim_input():
+    lcpl = LocalClassifierPerLevel()
+    X = np.random.rand(1, 275, 3)
+    y = np.array([["a", "b", "c"]])
+    lcpl.fit(X, y)
+    predictions = lcpl.predict(X)

--- a/tests/test_LocalClassifierPerNode.py
+++ b/tests/test_LocalClassifierPerNode.py
@@ -276,3 +276,18 @@ def test_knn():
     check_is_fitted(lcpn)
     # predictions = lcpn.predict(X)
     # assert_array_equal(y, predictions)
+
+
+def test_fit_multiple_dim_input():
+    lcpn = LocalClassifierPerNode()
+    X = np.random.rand(1, 275, 3)
+    y = np.array([["a", "b", "c"]])
+    lcpn.fit(X, y)
+    check_is_fitted(lcpn)
+
+def test_predict_multiple_dim_input():
+    lcpn = LocalClassifierPerNode()
+    X = np.random.rand(1, 275, 3)
+    y = np.array([["a", "b", "c"]])
+    lcpn.fit(X, y)
+    predictions = lcpn.predict(X)

--- a/tests/test_LocalClassifierPerNode.py
+++ b/tests/test_LocalClassifierPerNode.py
@@ -285,9 +285,11 @@ def test_fit_multiple_dim_input():
     lcpn.fit(X, y)
     check_is_fitted(lcpn)
 
+
 def test_predict_multiple_dim_input():
     lcpn = LocalClassifierPerNode()
     X = np.random.rand(1, 275, 3)
     y = np.array([["a", "b", "c"]])
     lcpn.fit(X, y)
     predictions = lcpn.predict(X)
+    assert predictions is not None

--- a/tests/test_LocalClassifierPerParentNode.py
+++ b/tests/test_LocalClassifierPerParentNode.py
@@ -283,3 +283,4 @@ def test_predict_multiple_dim_input():
     y = np.array([["a", "b", "c"]])
     lcppn.fit(X, y)
     predictions = lcppn.predict(X)
+    assert predictions is not None

--- a/tests/test_LocalClassifierPerParentNode.py
+++ b/tests/test_LocalClassifierPerParentNode.py
@@ -267,3 +267,19 @@ def test_knn():
     check_is_fitted(lcppn)
     # predictions = lcppn.predict(X)
     # assert_array_equal(y, predictions)
+
+
+def test_fit_multiple_dim_input():
+    lcppn = LocalClassifierPerParentNode()
+    X = np.random.rand(1, 275, 3)
+    y = np.array([["a", "b", "c"]])
+    lcppn.fit(X, y)
+    check_is_fitted(lcppn)
+
+
+def test_predict_multiple_dim_input():
+    lcppn = LocalClassifierPerParentNode()
+    X = np.random.rand(1, 275, 3)
+    y = np.array([["a", "b", "c"]])
+    lcppn.fit(X, y)
+    predictions = lcppn.predict(X)


### PR DESCRIPTION
Image input data has 3 dimensions (rgb) per image and is then a list of images => has 4 dimensions. 

Currently, passing such inputs generates the following error -

```
Traceback (most recent call last):
  File "/home/paula/documents/mastersproject/hierarchical-explainability/animal_dataset/train_with_hiclass.py", line 8, in <module>
    my_classifier.fit(X_train, y_train)
  File "/home/paula/documents/mastersproject/hierarchical-explainability/.venv/lib/python3.11/site-packages/hiclass/LocalClassifierPerParentNode.py", line 100, in fit
    super()._pre_fit(X, y, sample_weight)
  File "/home/paula/documents/mastersproject/hierarchical-explainability/.venv/lib/python3.11/site-packages/hiclass/HierarchicalClassifier.py", line 138, in _pre_fit
    self.X_, self.y_ = self._validate_data(
                       ^^^^^^^^^^^^^^^^^^^^
  File "/home/paula/documents/mastersproject/hierarchical-explainability/.venv/lib/python3.11/site-packages/sklearn/base.py", line 622, in _validate_data
    X, y = check_X_y(X, y, **check_params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/paula/documents/mastersproject/hierarchical-explainability/.venv/lib/python3.11/site-packages/sklearn/utils/validation.py", line 1146, in check_X_y
    X = check_array(
        ^^^^^^^^^^^^
  File "/home/paula/documents/mastersproject/hierarchical-explainability/.venv/lib/python3.11/site-packages/sklearn/utils/validation.py", line 951, in check_array
    raise ValueError(
ValueError: Found array with dim 4. LocalClassifierPerParentNode expected <= 2.Traceback (most recent call last):
  File "/home/paula/documents/mastersproject/hierarchical-explainability/animal_dataset/train_with_hiclass.py", line 8, in <module>
    my_classifier.fit(X_train, y_train)
  File "/home/paula/documents/mastersproject/hierarchical-explainability/.venv/lib/python3.11/site-packages/hiclass/LocalClassifierPerParentNode.py", line 100, in fit
    super()._pre_fit(X, y, sample_weight)
  File "/home/paula/documents/mastersproject/hierarchical-explainability/.venv/lib/python3.11/site-packages/hiclass/HierarchicalClassifier.py", line 138, in _pre_fit
    self.X_, self.y_ = self._validate_data(
                       ^^^^^^^^^^^^^^^^^^^^
  File "/home/paula/documents/mastersproject/hierarchical-explainability/.venv/lib/python3.11/site-packages/sklearn/base.py", line 622, in _validate_data
    X, y = check_X_y(X, y, **check_params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/paula/documents/mastersproject/hierarchical-explainability/.venv/lib/python3.11/site-packages/sklearn/utils/validation.py", line 1146, in check_X_y
    X = check_array(
        ^^^^^^^^^^^^
  File "/home/paula/documents/mastersproject/hierarchical-explainability/.venv/lib/python3.11/site-packages/sklearn/utils/validation.py", line 951, in check_array
    raise ValueError(
ValueError: Found array with dim 4. LocalClassifierPerParentNode expected <= 2.
```

This solution simply supplies the parameter `allow_nd=True` in the fit pipeline and `allow_nd=True, ensure_2d=False` in the predict pipeline to ensure the support of multi dimensional inputs.