### PR TITLE
Fix future warning

### DIFF
--- a/hiclass/HierarchicalClassifier.py
+++ b/hiclass/HierarchicalClassifier.py
@@ -11,14 +11,21 @@ import scipy
 from joblib import Parallel, delayed
 from sklearn.base import BaseEstimator
 from sklearn.linear_model import LogisticRegression
-from sklearn.utils.validation import (_check_sample_weight, check_array,
-                                      check_is_fitted, validate_data)
+from sklearn.utils.validation import (
+    _check_sample_weight,
+    check_array,
+    check_is_fitted,
+    validate_data,
+)
 
-from hiclass.probability_combiner import (ArithmeticMeanCombiner,
-                                          GeometricMeanCombiner,
-                                          MultiplyCombiner)
-from hiclass.probability_combiner import \
-    init_strings as probability_combiner_init_strings
+from hiclass.probability_combiner import (
+    ArithmeticMeanCombiner,
+    GeometricMeanCombiner,
+    MultiplyCombiner,
+)
+from hiclass.probability_combiner import (
+    init_strings as probability_combiner_init_strings,
+)
 
 try:
     import ray

--- a/hiclass/HierarchicalClassifier.py
+++ b/hiclass/HierarchicalClassifier.py
@@ -11,18 +11,14 @@ import scipy
 from joblib import Parallel, delayed
 from sklearn.base import BaseEstimator
 from sklearn.linear_model import LogisticRegression
-from sklearn.utils.validation import _check_sample_weight
-from sklearn.utils.validation import check_array, check_is_fitted
+from sklearn.utils.validation import (_check_sample_weight, check_array,
+                                      check_is_fitted, validate_data)
 
-from hiclass.probability_combiner import (
-    GeometricMeanCombiner,
-    ArithmeticMeanCombiner,
-    MultiplyCombiner,
-)
-
-from hiclass.probability_combiner import (
-    init_strings as probability_combiner_init_strings,
-)
+from hiclass.probability_combiner import (ArithmeticMeanCombiner,
+                                          GeometricMeanCombiner,
+                                          MultiplyCombiner)
+from hiclass.probability_combiner import \
+    init_strings as probability_combiner_init_strings
 
 try:
     import ray
@@ -173,8 +169,8 @@ class HierarchicalClassifier(abc.ABC):
         # Check that X and y have correct shape
         # and convert them to np.ndarray if need be
 
-        self.X_, self.y_ = self._validate_data(
-            X, y, multi_output=True, accept_sparse="csr", allow_nd=True
+        self.X_, self.y_ = validate_data(
+            self, X, y, multi_output=True, accept_sparse="csr", allow_nd=True
         )
 
         if sample_weight is not None:


### PR DESCRIPTION
FutureWarning: `BaseEstimator._validate_data` is deprecated in 1.6 and will be removed in 1.7. Use `sklearn.utils.validation.validate_data` instead. This function becomes public and is part of the scikit-learn developer API.