### PR TITLE
Fix lcppn predict_proba

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -27,6 +27,7 @@ pandas = "1.4.2"
 black = {version = "24.3.0", extras = ["colorama"]}
 pre-commit = "2.20.0"
 pyfakefs = "*"
+hypothesis = "*"
 
 [extras]
 ray = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "e04b6696c83be3a0dd3d4593c19f027b9a703a7e9e51bdb336d8eea0fd2458e6"
+            "sha256": "41dac46b8fb89035c1d671a16f7c6fa52f700816207ee5b63ec62658fbf465b7"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -152,13 +152,6 @@
             "markers": "python_version >= '3.9'",
             "version": "==0.7.16"
         },
-        "atomicwrites": {
-            "hashes": [
-                "sha256:81b2c9071a49367a7f770170e5eec8cb66567cfbbc8c73d20ce5ca4a8d71cf11"
-            ],
-            "markers": "sys_platform == 'win32'",
-            "version": "==1.4.1"
-        },
         "attrs": {
             "hashes": [
                 "sha256:5cfb1b9148b5b086569baec03f20d7b6bf3bcacc9a42bebf87ffaaca362f6346",
@@ -174,14 +167,6 @@
             ],
             "markers": "python_version >= '3.8'",
             "version": "==2.16.0"
-        },
-        "backports.tarfile": {
-            "hashes": [
-                "sha256:77e284d754527b01fb1e6fa8a1afe577858ebe4e9dad8919e34c862cb399bc34",
-                "sha256:d75e02c268746e1b8144c278978b6e98e85de6ad16f8e4b0844a154557eca991"
-            ],
-            "markers": "python_version < '3.12'",
-            "version": "==1.2.0"
         },
         "black": {
             "extras": [
@@ -213,22 +198,6 @@
             ],
             "markers": "python_version >= '3.8'",
             "version": "==24.3.0"
-        },
-        "boto3": {
-            "hashes": [
-                "sha256:7bc78d7140c353b10a637927fe4bc4c4d95a464d1b8f515d5844def2ee52cbd5",
-                "sha256:c3e138e9041d59cd34cdc28a587dfdc899dba02ea26ebc3e10fb4bc88e5cf31b"
-            ],
-            "markers": "python_version >= '3.8'",
-            "version": "==1.35.14"
-        },
-        "botocore": {
-            "hashes": [
-                "sha256:24823135232f88266b66ae8e1d0f3d40872c14cd976781f7fe52b8f0d79035a0",
-                "sha256:8515a2fc7ca5bcf0b10016ba05ccf2d642b7cb77d8773026ff2fa5aa3bf38d2e"
-            ],
-            "markers": "python_version >= '3.8'",
-            "version": "==1.35.14"
         },
         "certifi": {
             "hashes": [
@@ -349,14 +318,6 @@
             ],
             "markers": "python_version >= '3.7'",
             "version": "==8.1.7"
-        },
-        "cloudpickle": {
-            "hashes": [
-                "sha256:246ee7d0c295602a036e86369c77fecda4ab17b506496730f2f576d9016fd9c7",
-                "sha256:996d9a482c6fb4f33c1a35335cf8afd065d2a56e973270364840712d9131a882"
-            ],
-            "markers": "python_version >= '3.8'",
-            "version": "==3.0.0"
         },
         "colorama": {
             "hashes": [
@@ -606,13 +567,14 @@
             "markers": "python_version >= '3.8'",
             "version": "==4.53.1"
         },
-        "fsspec": {
+        "hypothesis": {
             "hashes": [
-                "sha256:4b0afb90c2f21832df142f292649035d80b421f60a9e1c027802e5a0da2b04e8",
-                "sha256:a0947d552d8a6efa72cc2c730b12c41d043509156966cca4fb157b0f2a0c574b"
+                "sha256:ac263bdaf338f4899a9a56e8224304e29b3ad91799e0274783c49abd91ea35ac",
+                "sha256:caf1f752418c49ac805f11d909c5831aaceb96762aa3895e0c702468dedbe3fe"
             ],
-            "markers": "python_version >= '3.8'",
-            "version": "==2024.9.0"
+            "index": "pypi",
+            "markers": "python_version >= '3.10'",
+            "version": "==6.150.0"
         },
         "identify": {
             "hashes": [
@@ -637,14 +599,6 @@
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==1.4.1"
-        },
-        "importlib-metadata": {
-            "hashes": [
-                "sha256:66f342cc6ac9818fc6ff340576acd24d65ba0b3efabb2b4ac08b598965a4a2f1",
-                "sha256:9a547d3bc3608b025f93d403fdd1aae741c24fbb8314df4b155675742ce303c5"
-            ],
-            "markers": "python_version >= '3.8'",
-            "version": "==8.4.0"
         },
         "iniconfig": {
             "hashes": [
@@ -685,22 +639,6 @@
             ],
             "markers": "python_version >= '3.7'",
             "version": "==3.1.4"
-        },
-        "jmespath": {
-            "hashes": [
-                "sha256:02e2e4cc71b5bcab88332eebf907519190dd9e6e82107fa7f83b1003a6252980",
-                "sha256:90261b206d6defd58fdd5e85f478bf633a2901798906be2ad389150c5c60edbe"
-            ],
-            "markers": "python_version >= '3.7'",
-            "version": "==1.0.1"
-        },
-        "joblib": {
-            "hashes": [
-                "sha256:06d478d5674cbc267e7496a410ee875abd68e4340feff4490bcb7afb88060ae6",
-                "sha256:2382c5816b2636fbd20a09e0f4e9dad4736765fdfb7dca582943b9c1366b3f0e"
-            ],
-            "markers": "python_version >= '3.8'",
-            "version": "==1.4.2"
         },
         "keyring": {
             "hashes": [
@@ -829,33 +767,6 @@
             ],
             "markers": "python_version >= '3.8'",
             "version": "==1.4.7"
-        },
-        "llvmlite": {
-            "hashes": [
-                "sha256:14f0e4bf2fd2d9a75a3534111e8ebeb08eda2f33e9bdd6dfa13282afacdde0ed",
-                "sha256:18e9953c748b105668487b7c81a3e97b046d8abf95c4ddc0cd3c94f4e4651ae8",
-                "sha256:35d80d61d0cda2d767f72de99450766250560399edc309da16937b93d3b676e7",
-                "sha256:3e8d0618cb9bfe40ac38a9633f2493d4d4e9fcc2f438d39a4e854f39cc0f5f98",
-                "sha256:47e147cdda9037f94b399bf03bfd8a6b6b1f2f90be94a454e3386f006455a9b4",
-                "sha256:6912a87782acdff6eb8bf01675ed01d60ca1f2551f8176a300a886f09e836a6a",
-                "sha256:6d4fd101f571a31acb1559ae1af30f30b1dc4b3186669f92ad780e17c81e91bc",
-                "sha256:74937acd22dc11b33946b67dca7680e6d103d6e90eeaaaf932603bec6fe7b03a",
-                "sha256:7a2872ee80dcf6b5dbdc838763d26554c2a18aa833d31a2635bff16aafefb9c9",
-                "sha256:7d434ec7e2ce3cc8f452d1cd9a28591745de022f931d67be688a737320dfcead",
-                "sha256:977525a1e5f4059316b183fb4fd34fa858c9eade31f165427a3977c95e3ee749",
-                "sha256:9cd2a7376f7b3367019b664c21f0c61766219faa3b03731113ead75107f3b66c",
-                "sha256:a289af9a1687c6cf463478f0fa8e8aa3b6fb813317b0d70bf1ed0759eab6f761",
-                "sha256:ae2b5b5c3ef67354824fb75517c8db5fbe93bc02cd9671f3c62271626bc041d5",
-                "sha256:bc9efc739cc6ed760f795806f67889923f7274276f0eb45092a1473e40d9b867",
-                "sha256:c1da416ab53e4f7f3bc8d4eeba36d801cc1894b9fbfbf2022b29b6bad34a7df2",
-                "sha256:d5bd550001d26450bd90777736c69d68c487d17bf371438f975229b2b8241a91",
-                "sha256:df6509e1507ca0760787a199d19439cc887bfd82226f5af746d6977bd9f66844",
-                "sha256:e0a9a1a39d4bf3517f2af9d23d479b4175ead205c592ceeb8b89af48a327ea57",
-                "sha256:eccce86bba940bae0d8d48ed925f21dbb813519169246e2ab292b5092aba121f",
-                "sha256:f99b600aa7f65235a5a05d0b9a9f31150c390f31261f2a0ba678e26823ec38f7"
-            ],
-            "markers": "python_version >= '3.9'",
-            "version": "==0.43.0"
         },
         "markdown-it-py": {
             "hashes": [
@@ -1001,13 +912,6 @@
             "markers": "python_version >= '3.8'",
             "version": "==10.5.0"
         },
-        "mpmath": {
-            "hashes": [
-                "sha256:7a28eb2a9774d00c7bc92411c19a89209d5da7c4c9a9e227be8330a23a25b91f",
-                "sha256:a0b2b9fe80bbcd81a6647ff13108738cfb482d481d826cc0e02f5b35e5c88d2c"
-            ],
-            "version": "==1.3.0"
-        },
         "mypy-extensions": {
             "hashes": [
                 "sha256:4392f6c0eb8a5668a69e23d168ffa70f0be9ccfd32b5cc2d26a34ae5b844552d",
@@ -1015,15 +919,6 @@
             ],
             "markers": "python_version >= '3.5'",
             "version": "==1.0.0"
-        },
-        "networkx": {
-            "hashes": [
-                "sha256:0c127d8b2f4865f59ae9cb8aafcd60b5c70f3241ebd66f7defad7c4ab90126c9",
-                "sha256:28575580c6ebdaf4505b22c6256a2b9de86b316dc63ba9e93abde3d78dfdbcf2"
-            ],
-            "index": "pypi",
-            "markers": "python_version >= '3.10'",
-            "version": "==3.3"
         },
         "nh3": {
             "hashes": [
@@ -1053,33 +948,6 @@
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5, 3.6'",
             "version": "==1.9.1"
-        },
-        "numba": {
-            "hashes": [
-                "sha256:01ef4cd7d83abe087d644eaa3d95831b777aa21d441a23703d649e06b8e06b74",
-                "sha256:0b983bd6ad82fe868493012487f34eae8bf7dd94654951404114f23c3466d34b",
-                "sha256:0ebaa91538e996f708f1ab30ef4d3ddc344b64b5227b67a57aa74f401bb68b9d",
-                "sha256:1527dc578b95c7c4ff248792ec33d097ba6bef9eda466c948b68dfc995c25781",
-                "sha256:159e618ef213fba758837f9837fb402bbe65326e60ba0633dbe6c7f274d42c1b",
-                "sha256:19407ced081d7e2e4b8d8c36aa57b7452e0283871c296e12d798852bc7d7f198",
-                "sha256:3031547a015710140e8c87226b4cfe927cac199835e5bf7d4fe5cb64e814e3ab",
-                "sha256:38d6ea4c1f56417076ecf8fc327c831ae793282e0ff51080c5094cb726507b1c",
-                "sha256:3fb02b344a2a80efa6f677aa5c40cd5dd452e1b35f8d1c2af0dfd9ada9978e4b",
-                "sha256:4142d7ac0210cc86432b818338a2bc368dc773a2f5cf1e32ff7c5b378bd63ee8",
-                "sha256:5d761de835cd38fb400d2c26bb103a2726f548dc30368853121d66201672e651",
-                "sha256:5df6158e5584eece5fc83294b949fd30b9f1125df7708862205217e068aabf16",
-                "sha256:5f4fde652ea604ea3c86508a3fb31556a6157b2c76c8b51b1d45eb40c8598703",
-                "sha256:62908d29fb6a3229c242e981ca27e32a6e606cc253fc9e8faeb0e48760de241e",
-                "sha256:819a3dfd4630d95fd574036f99e47212a1af41cbcb019bf8afac63ff56834449",
-                "sha256:a17b70fc9e380ee29c42717e8cc0bfaa5556c416d94f9aa96ba13acb41bdece8",
-                "sha256:c151748cd269ddeab66334bd754817ffc0cabd9433acb0f551697e5151917d25",
-                "sha256:cac02c041e9b5bc8cf8f2034ff6f0dbafccd1ae9590dc146b3a02a45e53af4e2",
-                "sha256:d7da4098db31182fc5ffe4bc42c6f24cd7d1cb8a14b59fd755bfee32e34b8404",
-                "sha256:f75262e8fe7fa96db1dca93d53a194a38c46da28b112b8a4aca168f0df860347",
-                "sha256:fe0b28abb8d70f8160798f4de9d486143200f34458d34c4a214114e445d7124e"
-            ],
-            "markers": "python_version >= '3.9'",
-            "version": "==0.60.0"
         },
         "numpy": {
             "hashes": [
@@ -1254,14 +1122,6 @@
             "markers": "python_version >= '3.8'",
             "version": "==10.4.0"
         },
-        "pkginfo": {
-            "hashes": [
-                "sha256:5df73835398d10db79f8eecd5cd86b1f6d29317589ea70796994d49399af6297",
-                "sha256:889a6da2ed7ffc58ab5b900d888ddce90bce912f2d2de1dc1c26f4cb9fe65097"
-            ],
-            "markers": "python_version >= '3.6'",
-            "version": "==1.10.0"
-        },
         "platformdirs": {
             "hashes": [
                 "sha256:63b79589009fa8159973601dd4563143396b35c5f93a58b36f9049ff046949b1",
@@ -1394,14 +1254,6 @@
             ],
             "version": "==2024.1"
         },
-        "pywin32-ctypes": {
-            "hashes": [
-                "sha256:8a1513379d709975552d202d942d9837758905c8d01eb82b8bcc30918929e7b8",
-                "sha256:d162dc04946d704503b2edc4d55f3dba5c1d539ead017afa00142c38b9885755"
-            ],
-            "markers": "sys_platform == 'win32'",
-            "version": "==0.2.3"
-        },
         "pyyaml": {
             "hashes": [
                 "sha256:01179a4a8559ab5de078078f37e5c1a30d76bb88519906844fd7bdea1b7729ff",
@@ -1510,105 +1362,6 @@
             "markers": "python_full_version >= '3.7.0'",
             "version": "==13.8.0"
         },
-        "s3transfer": {
-            "hashes": [
-                "sha256:0711534e9356d3cc692fdde846b4a1e4b0cb6519971860796e6bc4c7aea00ef6",
-                "sha256:eca1c20de70a39daee580aef4986996620f365c4e0fda6a86100231d62f1bf69"
-            ],
-            "markers": "python_version >= '3.8'",
-            "version": "==0.10.2"
-        },
-        "scikit-learn": {
-            "hashes": [
-                "sha256:1d0b25d9c651fd050555aadd57431b53d4cf664e749069da77f3d52c5ad14b3b",
-                "sha256:36f0ea5d0f693cb247a073d21a4123bdf4172e470e6d163c12b74cbb1536cf38",
-                "sha256:426d258fddac674fdf33f3cb2d54d26f49406e2599dbf9a32b4d1696091d4256",
-                "sha256:44c62f2b124848a28fd695db5bc4da019287abf390bfce602ddc8aa1ec186aae",
-                "sha256:45dee87ac5309bb82e3ea633955030df9bbcb8d2cdb30383c6cd483691c546cc",
-                "sha256:49d64ef6cb8c093d883e5a36c4766548d974898d378e395ba41a806d0e824db8",
-                "sha256:5460a1a5b043ae5ae4596b3126a4ec33ccba1b51e7ca2c5d36dac2169f62ab1d",
-                "sha256:5cd7b524115499b18b63f0c96f4224eb885564937a0b3477531b2b63ce331904",
-                "sha256:671e2f0c3f2c15409dae4f282a3a619601fa824d2c820e5b608d9d775f91780c",
-                "sha256:68b8404841f944a4a1459b07198fa2edd41a82f189b44f3e1d55c104dbc2e40c",
-                "sha256:81bf5d8bbe87643103334032dd82f7419bc8c8d02a763643a6b9a5c7288c5054",
-                "sha256:8539a41b3d6d1af82eb629f9c57f37428ff1481c1e34dddb3b9d7af8ede67ac5",
-                "sha256:87440e2e188c87db80ea4023440923dccbd56fbc2d557b18ced00fef79da0727",
-                "sha256:90378e1747949f90c8f385898fff35d73193dfcaec3dd75d6b542f90c4e89755",
-                "sha256:b0203c368058ab92efc6168a1507d388d41469c873e96ec220ca8e74079bf62e",
-                "sha256:c97a50b05c194be9146d61fe87dbf8eac62b203d9e87a3ccc6ae9aed2dfaf361",
-                "sha256:d36d0bc983336bbc1be22f9b686b50c964f593c8a9a913a792442af9bf4f5e68",
-                "sha256:d762070980c17ba3e9a4a1e043ba0518ce4c55152032f1af0ca6f39b376b5928",
-                "sha256:d9993d5e78a8148b1d0fdf5b15ed92452af5581734129998c26f481c46586d68",
-                "sha256:daa1c471d95bad080c6e44b4946c9390a4842adc3082572c20e4f8884e39e959",
-                "sha256:ff4effe5a1d4e8fed260a83a163f7dbf4f6087b54528d8880bab1d1377bd78be"
-            ],
-            "index": "pypi",
-            "markers": "python_version >= '3.9'",
-            "version": "==1.4.2"
-        },
-        "scipy": {
-            "hashes": [
-                "sha256:00150c5eae7b610c32589dda259eacc7c4f1665aedf25d921907f4d08a951b1c",
-                "sha256:028eccd22e654b3ea01ee63705681ee79933652b2d8f873e7949898dda6d11b6",
-                "sha256:1b7c3dca977f30a739e0409fb001056484661cb2541a01aba0bb0029f7b68db8",
-                "sha256:2c6ff6ef9cc27f9b3db93a6f8b38f97387e6e0591600369a297a50a8e96e835d",
-                "sha256:36750b7733d960d7994888f0d148d31ea3017ac15eef664194b4ef68d36a4a97",
-                "sha256:530f9ad26440e85766509dbf78edcfe13ffd0ab7fec2560ee5c36ff74d6269ff",
-                "sha256:5e347b14fe01003d3b78e196e84bd3f48ffe4c8a7b8a1afbcb8f5505cb710993",
-                "sha256:6550466fbeec7453d7465e74d4f4b19f905642c89a7525571ee91dd7adabb5a3",
-                "sha256:6df1468153a31cf55ed5ed39647279beb9cfb5d3f84369453b49e4b8502394fd",
-                "sha256:6e619aba2df228a9b34718efb023966da781e89dd3d21637b27f2e54db0410d7",
-                "sha256:8fce70f39076a5aa62e92e69a7f62349f9574d8405c0a5de6ed3ef72de07f446",
-                "sha256:90a2b78e7f5733b9de748f589f09225013685f9b218275257f8a8168ededaeaa",
-                "sha256:91af76a68eeae0064887a48e25c4e616fa519fa0d38602eda7e0f97d65d57937",
-                "sha256:933baf588daa8dc9a92c20a0be32f56d43faf3d1a60ab11b3f08c356430f6e56",
-                "sha256:acf8ed278cc03f5aff035e69cb511741e0418681d25fbbb86ca65429c4f4d9cd",
-                "sha256:ad669df80528aeca5f557712102538f4f37e503f0c5b9541655016dd0932ca79",
-                "sha256:b030c6674b9230d37c5c60ab456e2cf12f6784596d15ce8da9365e70896effc4",
-                "sha256:b9999c008ccf00e8fbcce1236f85ade5c569d13144f77a1946bef8863e8f6eb4",
-                "sha256:bc9a714581f561af0848e6b69947fda0614915f072dfd14142ed1bfe1b806710",
-                "sha256:ce7fff2e23ab2cc81ff452a9444c215c28e6305f396b2ba88343a567feec9660",
-                "sha256:cf00bd2b1b0211888d4dc75656c0412213a8b25e80d73898083f402b50f47e41",
-                "sha256:d10e45a6c50211fe256da61a11c34927c68f277e03138777bdebedd933712fea",
-                "sha256:ee410e6de8f88fd5cf6eadd73c135020bfbbbdfcd0f6162c36a7638a1ea8cc65",
-                "sha256:f313b39a7e94f296025e3cffc2c567618174c0b1dde173960cf23808f9fae4be",
-                "sha256:f3cd9e7b3c2c1ec26364856f9fbe78695fe631150f94cd1c22228456404cf1ec"
-            ],
-            "index": "pypi",
-            "markers": "python_version >= '3.9'",
-            "version": "==1.11.4"
-        },
-        "shap": {
-            "hashes": [
-                "sha256:1f19a3c531c6ceb0d7adea8262385580b52ef187981606342cd03288fc48cbfa",
-                "sha256:2ad3192026a0e4c3e399ef499da4f726ab01d62f388e03c804d8e10c4e61c8d1",
-                "sha256:3c873d26e4fdcdb9e6a83a1e05c1e9c8c8b48ac4365b0259d6e138afb3729c32",
-                "sha256:44ed7a80ae30ed3927f1bc7911f6f04bb32bb2d938a9e8a5794b2bb99e3b99cc",
-                "sha256:497bde2083b2a27e0a4b8ded09927c11c8803e80e76cb2e87e2136c49f1c93b2",
-                "sha256:4fa67a8810a042aa2366224afa612ded8a2a77b5a5a0d89ea60eba5eff3a0c1b",
-                "sha256:5fe63f1f4acf6bdfa3c85db85067d0fda2a29fe38be2d14a2811844f35290f43",
-                "sha256:62bb07b4748db004c78802494c29e5e70a2efff967a5c4d50209d2ee2ace16db",
-                "sha256:668ebe97c60a12bdffe254dfb2c8598cf24416e202b4b662076846b12d10b4b7",
-                "sha256:6aede800f0ec9efa8acd35913d791304d46376d444e8c6e1be905606e626c5e2",
-                "sha256:89f4492b406ec9908750560281c4616aff2a28c61f3ad2f6ac511270f44a0c5a",
-                "sha256:93a94961a355249855f13f1ed564466afa1c5fae84f868dd56e50e936f4f9b57",
-                "sha256:947c7e25b96d37763948ef2edd1711c6b3098a161de8e97fa0d1fdad6e49848c",
-                "sha256:a21d5a622e12e7c3b4a58d6e93b70133b7e09b6342b19746071a0dc2d190b432",
-                "sha256:a466d8a9bb12e7e07f13e68ea2859e4deb1dc6d3953c3a88310bd77484943cd6",
-                "sha256:ab36e2aecd0c1ba3df58f2452aa4aa24832ec766cbb2a794e2411897eb728b30",
-                "sha256:c82efde41d2b2c65d707b678a0d057d77436faf72331a623545aa742ffe5b9f5",
-                "sha256:d2919f2b255e31363182afb1627b374eb6c4724c90b0318719cbe90a316682f5",
-                "sha256:d65a21a64f3c1e76e1fb5277a0cfbcce447c08a26eaef311b1cbae9a6efe0ea0",
-                "sha256:dda26c39ac0ef17233deba09b0f313ceb4d5fa663dced2a1b77a494d48db96b8",
-                "sha256:e1c3de8747fb451e59768dca11b054e395a2a1601c7482738897616a70679419",
-                "sha256:e4ba4f3e84c3adf2c5a55e6d2becb7a4bb83e5784f7aa373316099a105ad593f",
-                "sha256:e98bb13dc351317ad2420dfe2dbca5361237ab9bef511fbe28ce6c1dfb40ff8c",
-                "sha256:febd7f0ad6ac27f999ed857a897f0f9963d4a4d9eeb003ee2505cf6164590d9c"
-            ],
-            "index": "pypi",
-            "markers": "python_version >= '3.8'",
-            "version": "==0.44.1"
-        },
         "six": {
             "hashes": [
                 "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926",
@@ -1617,20 +1370,19 @@
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==1.16.0"
         },
-        "slicer": {
-            "hashes": [
-                "sha256:0b94faa5251c0f23782c03f7b7eedda91d80144059645f452c4bc80fab875976",
-                "sha256:f5d5f7b45f98d155b9c0ba6554fa9770c6b26d5793a3e77a1030fb56910ebeec"
-            ],
-            "markers": "python_version >= '3.6'",
-            "version": "==0.0.7"
-        },
         "snowballstemmer": {
             "hashes": [
                 "sha256:09b16deb8547d3412ad7b590689584cd0fe25ec8db3be37788be3810cbf19cb1",
                 "sha256:c8e1716e83cc398ae16824e5572ae04e0d9fc2c6b985fb0f900f5f0c96ecba1a"
             ],
             "version": "==2.2.0"
+        },
+        "sortedcontainers": {
+            "hashes": [
+                "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88",
+                "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0"
+            ],
+            "version": "==2.4.0"
         },
         "sphinx": {
             "hashes": [
@@ -1714,22 +1466,6 @@
             "markers": "python_version >= '3.9'",
             "version": "==2.0.0"
         },
-        "sympy": {
-            "hashes": [
-                "sha256:401449d84d07be9d0c7a46a64bd54fe097667d5e7181bfe67ec777be9e01cb13",
-                "sha256:c51d75517712f1aed280d4ce58506a4a88d635d6b5dd48b39102a7ae1f3fcfe9"
-            ],
-            "markers": "python_version >= '3.8'",
-            "version": "==1.13.2"
-        },
-        "threadpoolctl": {
-            "hashes": [
-                "sha256:082433502dd922bf738de0d8bcc4fdcbf0979ff44c42bd40f5af8a282f6fa107",
-                "sha256:56c1e26c150397e58c4926da8eeee87533b1e32bef131bd4bf6a2f45f3185467"
-            ],
-            "markers": "python_version >= '3.8'",
-            "version": "==3.5.0"
-        },
         "toml": {
             "hashes": [
                 "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b",
@@ -1746,40 +1482,6 @@
             "markers": "python_version >= '3.7'",
             "version": "==2.0.1"
         },
-        "torch": {
-            "hashes": [
-                "sha256:092e7c2280c860eff762ac08c4bdcd53d701677851670695e0c22d6d345b269c",
-                "sha256:0b5f88afdfa05a335d80351e3cea57d38e578c8689f751d35e0ff36bce872113",
-                "sha256:18835374f599207a9e82c262153c20ddf42ea49bc76b6eadad8e5f49729f6e4d",
-                "sha256:362f82e23a4cd46341daabb76fba08f04cd646df9bfaf5da50af97cb60ca4971",
-                "sha256:40f6d3fe3bae74efcf08cb7f8295eaddd8a838ce89e9d26929d4edd6d5e4329d",
-                "sha256:5fc1d4d7ed265ef853579caf272686d1ed87cebdcd04f2a498f800ffc53dab71",
-                "sha256:6bce130f2cd2d52ba4e2c6ada461808de7e5eccbac692525337cfb4c19421846",
-                "sha256:72b484d5b6cec1a735bf3fa5a1c4883d01748698c5e9cfdbeb4ffab7c7987e0d",
-                "sha256:91e326e2ccfb1496e3bee58f70ef605aeb27bd26be07ba64f37dcaac3d070ada",
-                "sha256:a38de2803ee6050309aac032676536c3d3b6a9804248537e38e098d0e14817ec",
-                "sha256:b57f07e92858db78c5b72857b4f0b33a65b00dc5d68e7948a8494b0314efb880",
-                "sha256:c9299c16c9743001ecef515536ac45900247f4338ecdf70746f2461f9e4831db",
-                "sha256:c99e1db4bf0c5347107845d715b4aa1097e601bdc36343d758963055e9599d93",
-                "sha256:d36a8ef100f5bff3e9c3cea934b9e0d7ea277cb8210c7152d34a9a6c5830eadd",
-                "sha256:ddddbd8b066e743934a4200b3d54267a46db02106876d21cf31f7da7a96f98ea",
-                "sha256:e8ac1985c3ff0f60d85b991954cfc2cc25f79c84545aead422763148ed2759e3",
-                "sha256:ebea70ff30544fc021d441ce6b219a88b67524f01170b1c538d7d3ebb5e7f56c",
-                "sha256:ef503165f2341942bfdf2bd520152f19540d0c0e34961232f134dc59ad435be8",
-                "sha256:f18197f3f7c15cde2115892b64f17c80dbf01ed72b008020e7da339902742cf6",
-                "sha256:fdc4fe11db3eb93c1115d3e973a27ac7c1a8318af8934ffa36b0370efe28e042"
-            ],
-            "markers": "python_full_version >= '3.8.0'",
-            "version": "==2.4.1"
-        },
-        "tqdm": {
-            "hashes": [
-                "sha256:90279a3770753eafc9194a0364852159802111925aa30eb3f9d85b0e805ac7cd",
-                "sha256:e1020aef2e5096702d8a025ac7d16b1577279c9d63f8375b63083e9a5f0fcbad"
-            ],
-            "markers": "python_version >= '3.7'",
-            "version": "==4.66.5"
-        },
         "twine": {
             "hashes": [
                 "sha256:215dbe7b4b94c2c50a7315c0275d2258399280fbb7d04182c7e55e24b5f93997",
@@ -1788,14 +1490,6 @@
             "index": "pypi",
             "markers": "python_version >= '3.8'",
             "version": "==5.1.1"
-        },
-        "typing-extensions": {
-            "hashes": [
-                "sha256:04e5ca0351e0f3f85c6853954072df659d0d13fac324d0072316b67d7794700d",
-                "sha256:1a7ead55c7e559dd4dee8856e3a88b41225abfe1ce8df57b7c13915fe121ffb8"
-            ],
-            "markers": "python_version >= '3.8'",
-            "version": "==4.12.2"
         },
         "urllib3": {
             "hashes": [
@@ -1812,23 +1506,6 @@
             ],
             "markers": "python_version >= '3.7'",
             "version": "==20.26.4"
-        },
-        "xarray": {
-            "hashes": [
-                "sha256:7bee552751ff1b29dab8b7715726e5ecb56691ac54593cf4881dff41978ce0cd",
-                "sha256:7e530b1deafdd43e5c2b577d0944e6b528fbe88045fd849e49a8d11871ecd522"
-            ],
-            "index": "pypi",
-            "markers": "python_version >= '3.8'",
-            "version": "==2023.1.0"
-        },
-        "zipp": {
-            "hashes": [
-                "sha256:9960cd8967c8f85a56f920d5d507274e74f9ff813a0ab8889a5b5be2daf44064",
-                "sha256:c22b14cc4763c5a5b04134207736c107db42e9d3ef2d9779d465f5f1bcba572b"
-            ],
-            "markers": "python_version >= '3.8'",
-            "version": "==3.20.1"
         }
     },
     "extras": {

--- a/hiclass/LocalClassifierPerParentNode.py
+++ b/hiclass/LocalClassifierPerParentNode.py
@@ -217,9 +217,6 @@ class LocalClassifierPerParentNode(BaseEstimator, HierarchicalClassifier):
 
         self.logger_.info("Predicting Probability")
 
-        # Initialize array that holds predictions
-        y = np.empty((X.shape[0], self.max_levels_), dtype=self.dtype_)
-
         # Predict first level
         classifier = self.hierarchy_.nodes[self.root_]["classifier"]
         # use classifier as a fallback if no calibrator is available
@@ -229,8 +226,7 @@ class LocalClassifierPerParentNode(BaseEstimator, HierarchicalClassifier):
         )
         proba = calibrator.predict_proba(X)
 
-        y[:, 0] = calibrator.classes_[np.argmax(proba, axis=1)]
-        level_probability_list = [proba] + self._predict_proba_remaining_levels(X, y)
+        level_probability_list = [proba] + self._predict_proba_remaining_levels(X)
 
         level_probability_list = self._combine_and_reorder(level_probability_list)
 
@@ -252,18 +248,16 @@ class LocalClassifierPerParentNode(BaseEstimator, HierarchicalClassifier):
             else level_probability_list[-1]
         )
 
-    def _predict_proba_remaining_levels(self, X, y):
+    def _predict_proba_remaining_levels(self, X):
         level_probability_list = []
-        for level in range(1, y.shape[1]):
-            predecessors = set(y[:, level - 1])
+        for level in range(1, len(self.global_classes_)):
+            predecessors = set(self.global_classes_[level - 1])
             predecessors.discard("")
             level_dimension = self.max_level_dimensions_[level]
             cur_level_probabilities = np.zeros((X.shape[0], level_dimension))
 
             for predecessor in predecessors:
-                mask = np.isin(y[:, level - 1], self.global_classes_[level - 1])
-                predecessor_x = X[mask]
-                if predecessor_x.shape[0] > 0:
+                if X.shape[0] > 0:
                     successors = list(self.hierarchy_.successors(predecessor))
                     if len(successors) > 0:
                         classifier = self.hierarchy_.nodes[predecessor]["classifier"]
@@ -275,8 +269,7 @@ class LocalClassifierPerParentNode(BaseEstimator, HierarchicalClassifier):
                             or classifier
                         )
 
-                        proba = calibrator.predict_proba(predecessor_x)
-                        y[mask, level] = calibrator.classes_[np.argmax(proba, axis=1)]
+                        proba = calibrator.predict_proba(X)
 
                         for successor in successors:
                             class_index = self.global_class_to_index_mapping_[level][
@@ -286,7 +279,7 @@ class LocalClassifierPerParentNode(BaseEstimator, HierarchicalClassifier):
                             proba_index = np.where(calibrator.classes_ == successor)[0][
                                 0
                             ]
-                            cur_level_probabilities[mask, class_index] = proba[
+                            cur_level_probabilities[:, class_index] = proba[
                                 :, proba_index
                             ]
 

--- a/tests/test_LocalClassifierPerParentNode.py
+++ b/tests/test_LocalClassifierPerParentNode.py
@@ -1,9 +1,13 @@
 import logging
 import tempfile
 
+import hypothesis as hp
 import networkx as nx
 import numpy as np
+import numpy.typing as npt
 import pytest
+from hypothesis import strategies as st
+from hypothesis.extra.numpy import arrays
 from numpy.testing import assert_array_almost_equal, assert_array_equal
 from scipy.sparse import csr_matrix
 from sklearn.exceptions import NotFittedError
@@ -375,3 +379,44 @@ def test_fit_calibrate_predict_proba():
     assert_array_almost_equal(
         np.sum(proba[1], axis=1), np.ones(len(proba[1])), decimal=10
     )
+
+
+def test_predict_proba_does_not_depend_on_samples_in_batch() -> None:
+    train_x = np.array([[0], [1]])
+    train_y = [[0, 0], [1, 1]]
+    classifier = LocalClassifierPerParentNode()
+    classifier.fit(train_x, train_y)
+    predict_all_take_first = classifier.predict_proba(train_x)[0]
+    predict_first_take_first = classifier.predict_proba(train_x[:1])[0]
+    np.testing.assert_allclose(predict_all_take_first, predict_first_take_first)
+
+
+@st.composite
+def data_pair(draw: st.DrawFn) -> tuple[npt.NDArray[np.float32], npt.NDArray[np.int8]]:
+    num_samples = draw(st.integers(min_value=1, max_value=100))
+
+    num_features = draw(st.integers(min_value=1, max_value=1_000))
+    num_targets = draw(st.integers(min_value=1, max_value=10))
+
+    data_x = draw(
+        arrays(
+            dtype=np.float32,
+            shape=(num_samples, num_features),
+            elements=st.floats(allow_nan=False, allow_infinity=False, width=32),
+        )
+    )
+    data_y = draw(arrays(dtype=np.int8, shape=(num_samples, num_targets)))
+
+    return data_x, data_y
+
+
+@hp.given(data_pair())
+def test_fuzzy_predict_proba_does_not_depend_on_samples_in_batch(
+    pair: tuple[npt.NDArray[np.float32], npt.NDArray[np.int8]]
+) -> None:
+    data_x, data_y = pair
+    classifier = LocalClassifierPerParentNode()
+    classifier.fit(data_x, data_y)
+    predict_all_take_first = classifier.predict_proba(data_x)[0]
+    predict_first_take_first = classifier.predict_proba(data_x[:1])[0]
+    np.testing.assert_allclose(predict_all_take_first, predict_first_take_first)


### PR DESCRIPTION
Closes https://github.com/scikit-learn-contrib/hiclass/issues/159

So the main issue seems to be  that we are looking for predecessors in a set of our predictions for classes for all samples in the batch (257-258). Instead, i believe, we should compute probabilities for all classes.
We also don't need `mask` because it seems to be always true and it looks like we don't need to predict `y` at all.